### PR TITLE
Log the received value for easier debugging

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -883,7 +883,7 @@ func completeListValue(eCtx *executionContext, returnType *List, fieldASTs []*as
 	err := invariantf(
 		resultVal.IsValid() && isIterable(result),
 		"User Error: expected iterable, but did not find one "+
-			"for field %v.%v.", parentTypeName, info.FieldName)
+			`for field %v.%v, received "%v".`, parentTypeName, info.FieldName, resultVal)
 
 	if err != nil {
 		panic(gqlerrors.FormatError(err))

--- a/executor.go
+++ b/executor.go
@@ -883,7 +883,7 @@ func completeListValue(eCtx *executionContext, returnType *List, fieldASTs []*as
 	err := invariantf(
 		resultVal.IsValid() && isIterable(result),
 		"User Error: expected iterable, but did not find one "+
-			`for field %v.%v, received "%v".`, parentTypeName, info.FieldName, resultVal)
+			`for field %v.%v, received "%+v".`, parentTypeName, info.FieldName, resultVal)
 
 	if err != nil {
 		panic(gqlerrors.FormatError(err))


### PR DESCRIPTION
Log the original value when the underlying value doesn't follow the schema for easier debugging. 

Example output:

```
User Error: expected iterable, but did not find one for field TestLogEntry.cycleIndices, received \"testValue\".
```